### PR TITLE
Update index.sass

### DIFF
--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -68,7 +68,7 @@ $badge-shadow: 0 0 0 2px $scheme-main !default
     color: $scheme-main
     font-size: $badge-font-size
     height: $badge-height
-    line-height: calc(#{$badge-height / 2} + 1px)
+    line-height: calc(#{$badge-height * 0.5} + 1px)
     min-width: $badge-height
     overflow: hidden
     padding: $badge-padding


### PR DESCRIPTION
fixes this message:
```sh
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
```